### PR TITLE
Fix typos and annotations, code cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Poptracker Packbuilder-Script
+# PopTracker Packbuilder-Script
 
-This set of scripts is build to make it easier to start making a trackerpack for [Poptracker](https://github.com/black-sliver/PopTracker)
-Its builds the base file- and folder-structure expected from Poptracker from scratch based on the [Archipelago](https://archipelago.gg/)-Datapackages
+This set of scripts is build to make it easier to start making a trackerpack for [PopTracker](https://github.com/black-sliver/PopTracker)
+Its builds the base file- and folder-structure expected from PopTracker from scratch based on the [Archipelago](https://archipelago.gg/)-Datapackages
 
 
 ## Getting started
 
-This script is still work in progress but already creates packs working with Poptracker version from 0.27.0 onwards (as
+This script is still work in progress but already creates packs working with PopTracker version from 0.27.0 onwards (as
 of Aug 2024)
 
 To use this script you need to have [Python](https://www.python.org/downloads/) installed. tested with 3.11+ earlier
@@ -24,7 +24,7 @@ When you are starting to Build a fresh pack you will need to run `builder.py` wh
 
 It will ask you so select a folder to create the packs base-structure into. 
 *Ideally this folder is empty to have a clean working area* but preexisting folders and files wont be overwritten unless
-they conflict with the naming scheme for Poptracker.
+they conflict with the naming scheme for PopTracker.
 Next the Pack askes for a source, an URL or path to a JSON, to fetch the needed Datapackage from. 
 
 For the URL part this can be `https://archipelago.gg/datapackage` for supported Games or i.e
@@ -48,7 +48,7 @@ After creating these 2 files alongeside the folder-basestructure and some other 
 
 ### Manual editing of the 2 main files
 
-For a better explanaition of the terminology used here reference the [Poptracker Packs Interface-Guide](https://github.com/black-sliver/PopTracker/blob/master/doc/PACKS.md)
+For a better explanaition of the terminology used here reference the [PopTracker Packs Interface-Guide](https://github.com/black-sliver/PopTracker/blob/master/doc/PACKS.md)
 
 These 2 main files follow a relativly strict form that need to be maintained if you want to use this script any further
 or later on to reset/redo parts of the pack.
@@ -57,15 +57,15 @@ or later on to reset/redo parts of the pack.
 each line in `item_mapping.lua` looks like this:
 ```[<AP_item_ID>] = {{"<itemcode/-name>"}, "<item_type>"},```
 - AP_item_ID --> the ID send out by Archipelago for this specific item
-- itemcode/-name --> the code used to reference the item inside of Poptracker
-- item_type --> the type you want to classify the item as inside Poptracker. Possible types are:
+- itemcode/-name --> the code used to reference the item inside of PopTracker
+- item_type --> the type you want to classify the item as inside PopTracker. Possible types are:
 `"progressive", "toggle, "progressive_toggle", "static", "consumable" , "composite_toggle", and "composite_toggle"`
 although the last 2 (`"composite_toggle", and "composite_toggle"`) are ignored for the sake of simplicity in this script
 
 ##### To-Do's for Manual editing:
 - change the itemname/-code to something readable but ommit annotations like an amount. i.e from `money(500)` to just
   `money`, or `arrows(10)` to `arrows`. 
-- change the type to the one you want to use inside Poptracker to represent this item.
+- change the type to the one you want to use inside PopTracker to represent this item.
 
 all brackets need to stay the way they are!
 
@@ -91,7 +91,7 @@ happens if you dont group them at all.
 ##### To-Do's for Manual editing:
 
 - change the `AP_location_name` to a path you think best describes the location of the path inside your games world.
-  Poptracker calles them sections and if you will need to separate the differen layers of sections with `/`. 
+  PopTracker calles them sections and if you will need to separate the differen layers of sections with `/`. 
 Therese is no limit on how many separations you can make but at some points readablity __WILL__ suffer
 
 __caution__ : have a location names the same as section in the same place will cause the script to cause an error. so
@@ -132,11 +132,11 @@ After you are finished with editing both of these files you can run the script (
 It will ask again for the root folder of your pack. the same folder you selected previously and where all the folders
 and files already got created.
 This time the script will read the 2 mapping.lua files and create a bunch of json files containing all the needed
-information for Poptracker to know how to handle the items and how to structure the locations fully according to your
+information for PopTracker to know how to handle the items and how to structure the locations fully according to your
 manually edited structre. 
 __Items__
 When the script is finished you will have 1 files called items.json located in `items/items.json` containing all the
-information for your items ready for Poptracker to use. here you can now edit item-specific information such as the
+information for your items ready for PopTracker to use. here you can now edit item-specific information such as the
 imagename (defaults to `itemname.png`), the starting amount for consumables, and more.
 Images need to be provided separatety. the picture names dont need to match the autogenerated ones BUT they do need to
 match in the end....So rename the pictures AND/OR alter the paths in `items.json` 
@@ -156,10 +156,10 @@ for lvl in lvls:
         maps_names.append(lvl)
 ```
 __Layouts__
-Layout define you things are visibly structured in Poptracker. It is strongly recommendet to read about how structures
-work in the [Poptracker Packs Interface-Guide](https://github.com/black-sliver/PopTracker/blob/master/doc/PACKS.md).
+Layout define you things are visibly structured in PopTracker. It is strongly recommendet to read about how structures
+work in the [PopTracker Packs Interface-Guide](https://github.com/black-sliver/PopTracker/blob/master/doc/PACKS.md).
 The script creates multiple files to make things more readable but in the end they get loaded as nested imports from
-Poptracker. Play around with it to see how things work together but keep an untouched version or run `location_json.py`
+PopTracker. Play around with it to see how things work together but keep an untouched version or run `location_json.py`
 again to restore the default state from the script.
 
 ## Placing Section on a map

--- a/pythonProject/lua/archipelago.lua
+++ b/pythonProject/lua/archipelago.lua
@@ -38,7 +38,7 @@ Troll_Lookup = {
 ---@param o table
 ---@param depth? integer
 ---@return string
-function Dump_table(o, depth)
+function DumpTable(o, depth)
     if depth == nil then
         depth = 0
     end
@@ -50,7 +50,7 @@ function Dump_table(o, depth)
             if type(k) ~= 'number' then
                 k = '"' .. k .. '"'
             end
-            s = s .. tabs2 .. '[' .. k .. '] = ' .. Dump_table(v, depth + 1) .. ',\n'
+            s = s .. tabs2 .. '[' .. k .. '] = ' .. DumpTable(v, depth + 1) .. ',\n'
         end
         return s .. tabs .. '}'
     else
@@ -58,9 +58,9 @@ function Dump_table(o, depth)
     end
 end
 
----helper function that gets called when a locationSection has changed state.
+---helper function that gets called when a LocationSection has changed state.
 ---checks if the interaction was from the server or manual.
----if manual puts it into a cache for keeping that locationSection toggled when reconnecting
+---if manual, puts it into a cache for keeping that LocationSection toggled when reconnecting
 ---@param location LocationSection
 function LocationHandler(location)
     if MANUAL_CHECKED then
@@ -88,7 +88,7 @@ function LocationHandler(location)
         end
     end
     -- local custom_storage_item = Tracker:FindObjectForCode("manual_location_storage").ItemState
-    -- print(Dump_table(storage_item.ItemState.MANUAL_LOCATIONS))
+    -- print(DumpTable(storage_item.ItemState.MANUAL_LOCATIONS))
     ForceUpdate() --
 end
 
@@ -102,11 +102,11 @@ function ForceUpdate()
 end
 
 
----resets a give item back to default or whats saved for the gives seed in the pseuso-cache LuaItems
+---resets a given item back to default or what's saved for the given seed in the pseuso-cache LuaItems
 ---@param item_type string table of the ItemCode and extra parameters from the Item_Mapping.lau
----@param item_obj JsonItem Tracker:Findobject(item) retrun object
+---@param item_obj JsonItem Tracker:FindObjectForCode(item) return object
 ---@param item_code string Reference for the custom LuaItem CachesItems
-function ItemReset(item_type, item_obj, item_code)
+local function ItemReset(item_type, item_obj, item_code)
     if item_obj.Type == "toggle" then
         item_obj.Active = false
     elseif item_obj.Type == "progressive" then
@@ -125,9 +125,9 @@ end
 
 ---resets a given location back to default or whats saved for the gives seed in the pseuso-cache LuaItems
 ---@param location string String of the Location or LocatioSection to reset
----@param location_obj JsonItem|LocationSection Tracker:Findobject(location)retrun object
+---@param location_obj JsonItem|LocationSection Tracker:FindObjectForCode(location) return object
 ---@param custom_storage_item table Reference for the custom LuaItem CachesItems
-function LocationReset(location, location_obj, custom_storage_item)
+local function LocationReset(location, location_obj, custom_storage_item)
     if location:sub(1, 1) == "@" then
         ---@cast location_obj LocationSection
         if custom_storage_item.MANUAL_LOCATIONS[ROOM_SEED][location_obj.FullID] then
@@ -143,8 +143,8 @@ function LocationReset(location, location_obj, custom_storage_item)
 end
 
 
---- Function for prepare custom LuaItems for caching, check for mischieve/traps, subscribe to datastorage
-function PreOnClear()
+--- Function to prepare custom LuaItems for caching, check for mischieve/traps, subscribe to datastorage
+local function PreOnClear()
     PLAYER_ID = Archipelago.PlayerNumber or -1
 	TEAM_NUMBER = Archipelago.TeamNumber or 0
     if PLAYER_ID > -1 then
@@ -155,10 +155,10 @@ function PreOnClear()
             end
         end
 
-        --- example for how to build a date object and how to check current users date against it
-        --local start_day_range = Build_Time_Obj(nil, 3 , 31)
-        --local end_day_range = Build_Time_Obj(nil, 4 , 5)
-        --DATE_CHECK_PASSED = Check_Date_Range(start_day_range, end_day_range, os.time())
+        --- example for how to build a date object and how to check current user's date against it
+        --local start_day_range = BuildTimeObj(nil, 3 , 31)
+        --local end_day_range = BuildTimeObj(nil, 4 , 5)
+        --DATE_CHECK_PASSED = CheckDateRange(start_day_range, end_day_range, os.time())
         --if TROLL_PLAYER == false and DATE_CHECK_PASSED then
         --    TROLL_PLAYER = true
         --end
@@ -212,7 +212,7 @@ function OnClear(slot_data)
         CreateLuaManualStorageItem("manual_location_storage")
         custom_storage_item = Tracker:FindObjectForCode("manual_location_storage").ItemState
     end
-    -- repeat that here for every cache-storage item you create just to be save
+    -- repeat that here for every cache-storage item you create just to be safe
 
     PreOnClear()
 
@@ -247,7 +247,7 @@ function OnClear(slot_data)
     TEAM_NUMBER = Archipelago.TeamNumber or 0
     SLOT_DATA = slot_data
     -- if Tracker:FindObjectForCode("autofill_settings").Active == true then
-    --     autoFill(slot_data)
+    --     AutoFill(slot_data)
     -- end
     -- print(PLAYER_ID, TEAM_NUMBER)
     if Archipelago.PlayerNumber > -1 then
@@ -270,9 +270,9 @@ function OnClear(slot_data)
     MANUAL_CHECKED = true
 end
 
----Run every time an Item gets send to the connected slot
----@param index integer running index for the items the connected slot has receivied so far
----@param item_id integer itemID from the games datapackage the the send item
+---Run every time an Item gets sent to the connected slot
+---@param index integer running index for the items the connected slot has received so far
+---@param item_id integer ID of the received item, matching then game's datapackage ID
 ---@param item_name string name of the item from the datapackage for the given itemID
 ---@param player_number integer slotnumber of the player who picked up the item
 function OnItem(index, item_id, item_name, player_number)
@@ -320,8 +320,8 @@ function OnItem(index, item_id, item_name, player_number)
     end
 end
 
---called when a location gets cleared
----@param location_id integer ID of the locations cleared from the datapackage
+---called when a location gets cleared
+---@param location_id integer ID of the location cleared from the datapackage
 ---@param location_name string name of the location cleared from the datapackage
 function OnLocation(location_id, location_name)
     MANUAL_CHECKED = false
@@ -332,13 +332,13 @@ function OnLocation(location_id, location_name)
     end
 
     for _, location in pairs(location_array) do
-        local location_obj = Tracker:FindObjectForCode(location)  --[[@as LocationSection]]
+        local location_obj = Tracker:FindObjectForCode(location)
         -- print(location, location_obj)
         if location_obj then
             if location:sub(1, 1) == "@" then
-                location_obj.AvailableChestCount = location_obj.AvailableChestCount - 1
+                (location_obj --[[@as LocationSection]]).AvailableChestCount = location_obj.AvailableChestCount - 1
             else
-                location_obj.Active = true
+                (location_obj --[[@as JsonItem]]).Active = true
             end
         else
             print(string.format("OnLocation: could not find location_object for code %s", location))
@@ -347,14 +347,11 @@ function OnLocation(location_id, location_name)
     MANUAL_CHECKED = true
 end
 
--- this Autofill function is meant as an example on how to do the reading from slotdata and mapping the values to
--- your own settings
--- function autoFill()
---     if SLOT_DATA == nil  then
---         print("its fucked")
---         return
---     end
---     -- print(Dump_table(SLOT_DATA))
+-- this Autofill function is meant as an example on how to do the reading from slot_data
+-- and mapping the values to your own settings
+-- ---@param slot_data table
+-- function AutoFill(slot_data)
+--     -- print(DumpTable(slot_data))
 
 --     mapToggle={[0]=0,[1]=1,[2]=1,[3]=1,[4]=1}
 --     mapToggleReverse={[0]=1,[1]=0,[2]=0,[3]=0,[4]=0}
@@ -363,10 +360,9 @@ end
 --     slotCodes = {
 --         map_name = {code="", mapping=mapToggle...}
 --     }
---     -- print(Dump_table(SLOT_DATA))
 --     -- print(Tracker:FindObjectForCode("autofill_settings").Active)
 --     if Tracker:FindObjectForCode("autofill_settings").Active == true then
---         for settings_name , settings_value in pairs(SLOT_DATA) do
+--         for settings_name, settings_value in pairs(slot_data) do
 --             -- print(k, v)
 --             if slotCodes[settings_name] then
 --                 item = Tracker:FindObjectForCode(slotCodes[settings_name].code)
@@ -381,7 +377,7 @@ end
 --     end
 -- end
 
----@class APhint_message
+---@class APHintMessage
 ---@field receiving_player integer
 ---@field finding_player integer
 ---@field location integer
@@ -391,10 +387,37 @@ end
 ---@field item_flags 0|1|2|3|4|5|6|7
 ---@field status 0|10|20|30|40
 
----used on subsequent updatesfrom the server a given key we subscribed to
----@param key string
----@param value table<integer, APhint_message>
----@param old_value table<integer, APhint_message>
+---function to update the Highlight of a LocationSection to represent the status of the hint that is present
+---for that LocationSection
+---@param locationID integer ID of the locations the hint is being given for
+---@param status 0|10|20|30|40|100|101|102|103|104|105|106|107 status to determine the color of the hint glow
+local function UpdateHints(locationID, status) -->
+    if Highlight then
+        -- print(locationID, status)
+        local location_table = LOCATION_MAPPING[locationID]
+        for _, location in ipairs(location_table) do
+            if location:sub(1, 1) == "@" then
+				---@type LocationSection
+                local obj = Tracker:FindObjectForCode(location)
+
+                if obj then
+                    if TROLL_PLAYER and HIGHLIGHT_LEVEL[status] == Highlight.Avoid then
+                        obj.Highlight = HIGHLIGHT_LEVEL[30]
+                    else
+                        obj.Highlight = HIGHLIGHT_LEVEL[status]
+                    end
+                else
+                    print(string.format("No object found for code: %s", location))
+                end
+            end
+        end
+    end
+end
+
+---triggers as AP sends live updates from the server using a given key we subscribed to in Archipelago:SetNotify
+---@param key string Name of the key that was used to send the message
+---@param value table<integer, APHintMessage>
+---@param old_value table<integer, APHintMessage>
 function OnNotify(key, value, old_value)
     print("OnNotify", key, value, old_value)
     if value ~= old_value and key == HINTS_ID then
@@ -412,9 +435,9 @@ function OnNotify(key, value, old_value)
     end
 end
 
----used the very first time we receive this message from the server after subscribing to a given key
+---triggers on connecting to AP when we receive this message from the server after providing a given key to Archipelago:Get
 ---@param key string Name of the key that was used to send the message
----@param value table<integer, APhint_message>
+---@param value table<integer, APHintMessage>
 function OnNotifyLaunch(key, value)
     if key == HINTS_ID then
         Tracker.BulkUpdate = true
@@ -431,53 +454,27 @@ function OnNotifyLaunch(key, value)
     end
 end
 
----comment function to update the hint statu of a LocationSection to represent the status fo the hint that is present
---for that LocationSection
----@param locationID integer ID of the locations the hint is being given for
----@param status 0|10|20|30|40|100|101|102|103|104|105|106|107 status to determine the color of the hint glow
-function UpdateHints(locationID, status) -->
-    if Highlight then
-        -- print(locationID, status)
-        local location_table = LOCATION_MAPPING[locationID]
-        for _, location in ipairs(location_table) do
-            if location:sub(1, 1) == "@" then
-                local obj = Tracker:FindObjectForCode(location)
-
-                if obj then
-                    if TROLL_PLAYER and HIGHLIGHT_LEVEL[status] == Highlight.Avoid then
-                        obj.Highlight = HIGHLIGHT_LEVEL[30]
-                    else
-                        obj.Highlight = HIGHLIGHT_LEVEL[status]
-                    end
-                else
-                    print(string.format("No object found for code: %s", location))
-                end
-            end
-        end
-    end
-end
-
 -------------------
 ---this section is only for special things that are time of day or day of year dependant if you really want to do stuff
 ---stuff like this
 
----@param start_date number //build_time_obj() return aka unix timestamp
----@param end_date number //build_time_obj() return aka unix timestamp
----@param target_date number //build_time_obj() return aka unix timestamp
-function Check_Date_Range(start_date, end_date, target_date)
+---@param start_date number BuildTimeObj() return aka unix timestamp
+---@param end_date number BuildTimeObj() return aka unix timestamp
+---@param target_date number BuildTimeObj() return aka unix timestamp
+function CheckDateRange(start_date, end_date, target_date)
     local one_day = 86400
     local check_result = false
     for day_obj = start_date, end_date, one_day do
-        check_result = Check_Date(day_obj, target_date)
+        check_result = CheckDate(day_obj, target_date)
         if check_result then
             return true
         end
     end
 end
 
----@param target_date number //build_time_obj() return aka unix timestamp
----@param reference_time number? //build_time_obj() return aka unix timestamp
-function Check_Date(reference_time, target_date)
+---@param target_date number BuildTimeObj() return aka unix timestamp
+---@param reference_time number? BuildTimeObj() return aka unix timestamp
+function CheckDate(reference_time, target_date)
     local today = os.date("*t")
     local reference_day =  os.date("*t", target_date)
     if reference_time then
@@ -488,7 +485,7 @@ function Check_Date(reference_time, target_date)
     today.day == reference_day.day
 end
 
----helperfunctoin to return a date object for the provided day
+---helper function to return a date object for the provided day
 ---@param year number?
 ---@param month number?
 ---@param day number?
@@ -496,7 +493,7 @@ end
 ---@param minute number?
 ---@param second number?
 ---@return integer
-function Build_Time_Obj(year, month, day, hour, minute, second)
+function BuildTimeObj(year, month, day, hour, minute, second)
     local today = os.date("*t", os.time())
     return os.time(
         {
@@ -510,14 +507,6 @@ function Build_Time_Obj(year, month, day, hour, minute, second)
     )
 end
 -------------------
--- ScriptHost:AddWatchForCode("settings autofill handler", "autofill_settings", autoFill)
--- Archipelago:AddClearHandler("clear handler", OnClearHandler)
--- Archipelago:AddItemHandler("item handler", OnItem)
--- Archipelago:AddLocationHandler("location handler", OnLocation)
-
--- Archipelago:AddSetReplyHandler("notify handler", OnNotify)
--- Archipelago:AddRetrievedHandler("notify launch handler", OnNotifyLaunch)
-
 
 
 --doc

--- a/pythonProject/lua/archipelago.lua
+++ b/pythonProject/lua/archipelago.lua
@@ -1,5 +1,5 @@
-require("scripts/autotracking/item_mapping")
-require("scripts/autotracking/location_mapping")
+require("scripts.autotracking.item_mapping")
+require("scripts.autotracking.location_mapping")
 
 CUR_INDEX = -1
 --SLOT_DATA = nil

--- a/pythonProject/lua/archipelago.lua
+++ b/pythonProject/lua/archipelago.lua
@@ -224,7 +224,8 @@ function OnClear(slot_data)
     for _, location_array in pairs(LOCATION_MAPPING) do
         for _, location in pairs(location_array) do
             if location then
-                local location_obj = Tracker:FindObjectForCode(location) --[[@as LocationSection]]
+				---@type LocationSection
+                local location_obj = Tracker:FindObjectForCode(location)
                 if location_obj then
                     LocationReset(location, location_obj, custom_storage_item)
                 end
@@ -237,7 +238,8 @@ function OnClear(slot_data)
             local item_code = item_pair[1]
             local item_type = item_pair[2]
             -- print("on clear", item_code, item_type)
-            local item_obj = Tracker:FindObjectForCode(item_code) --[[@as JsonItem]]
+			---@type JsonItem
+            local item_obj = Tracker:FindObjectForCode(item_code)
             if item_obj then
                 ItemReset(item_type, item_obj, item_code)
             end

--- a/pythonProject/lua/archipelago.lua
+++ b/pythonProject/lua/archipelago.lua
@@ -274,7 +274,7 @@ end
 
 ---Run every time an Item gets sent to the connected slot
 ---@param index integer running index for the items the connected slot has received so far
----@param item_id integer ID of the received item, matching then game's datapackage ID
+---@param item_id integer ID of the received item, matching the game's datapackage ID
 ---@param item_name string name of the item from the datapackage for the given itemID
 ---@param player_number integer slotnumber of the player who picked up the item
 function OnItem(index, item_id, item_name, player_number)

--- a/pythonProject/lua/autotracking.lua
+++ b/pythonProject/lua/autotracking.lua
@@ -16,6 +16,6 @@ end
 print("---------------------------------------------------------------------")
 print("")
 
-require("scripts/settings")
+require("scripts.settings")
 -- loads the AP autotracking code
-require("scripts/autotracking/archipelago")
+require("scripts.autotracking.archipelago")

--- a/pythonProject/lua/init.lua
+++ b/pythonProject/lua/init.lua
@@ -1,25 +1,25 @@
 local variant = Tracker.ActiveVariantUID
 
 -- Items
-require("scripts/items_import")
+require("scripts.items_import")
 
 -- Logic
-require("scripts/logic/logic_helper")
-require("scripts/logic/base_logic")
-require("scripts/logic/graph_logic/logic_main")
+require("scripts.logic.logic_helper")
+require("scripts.logic.base_logic")
+require("scripts.logic.graph_logic.logic_main")
 
 -- Maps
 Tracker:AddMaps("maps/maps.json")
 
 -- Layout
-require("scripts/layouts_import")
+require("scripts.layouts_import")
 
 -- Locations
-require("scripts/locations_import")
+require("scripts.locations_import")
 
 -- AutoTracking for PopTracker
 if PopVersion and PopVersion >= "0.26.0" then
-    require("scripts/autotracking")
+    require("scripts.autotracking")
 end
 
 function OnFrameHandler()
@@ -30,6 +30,6 @@ function OnFrameHandler()
     CreateLuaManualStorageItem("manual_location_storage")
     ForceUpdate()
 end
-require("scripts/luaitems")
-require("scripts/watches")
+require("scripts.luaitems")
+require("scripts.watches")
 ScriptHost:AddOnFrameHandler("load handler", OnFrameHandler)

--- a/pythonProject/lua/init.lua
+++ b/pythonProject/lua/init.lua
@@ -17,7 +17,7 @@ require("scripts/layouts_import")
 -- Locations
 require("scripts/locations_import")
 
--- AutoTracking for Poptracker
+-- AutoTracking for PopTracker
 if PopVersion and PopVersion >= "0.26.0" then
     require("scripts/autotracking")
 end

--- a/pythonProject/lua/logic_helper.lua
+++ b/pythonProject/lua/logic_helper.lua
@@ -12,7 +12,7 @@ local bool_to_accesslvl = {
 
 ---helper to convert boolean return values to accessibility values for graph evaluation
 ---@param result boolean
----@return integer
+---@return accessibilityLevel
 function A(result)
     if result then
         return ACCESS_NORMAL
@@ -20,13 +20,12 @@ function A(result)
     return ACCESS_NONE
 end
 
----Takes in a arbitrary amount of arguments which themselfes are already evaluated function return values for having a
----certain item or being able to reach a certain location etc. combines these values and returns the minimum shared
----accessibility
----
----basically evaluates "are all requirements meet?"
----@param ... unknown
----@return integer
+---Takes in an arbitrary amount of arguments which are accessibilityLevels, booleans, item codes,
+---or functions that will return one of the previous three, and combines these values and
+---returns the minimum shared accessibility</br>
+---basically evaluates "are all requirements met?"
+---@param ... function|string|boolean|accessibilityLevel
+---@return accessibilityLevel
 function ALL(...)
     local args = { ... }
     local min = ACCESS_NORMAL
@@ -49,13 +48,12 @@ function ALL(...)
     return min
 end
 
----Takes in a arbitrary amount of arguments which themselfes are already evaluated function return values for having a
----certain item or being able to reach a certain location etc. combines these values and returns the maximum
----accessibility of any provided argument
----
----basically evaluates "is any 1 of the requirements meet?"
----@param ... unknown
----@return integer
+---Takes in an arbitrary amount of arguments which are accessibilityLevels, booleans, item codes,
+---or functions that will return one of the previous three, and combines these values and
+---returns the maximum accessibility of any provided argument</br>
+---basically evaluates "is any 1 of the requirements met?"
+---@param ... function|string|boolean|accessibilityLevel
+---@return accessibilityLevel
 function ANY(...)
     local args = { ... }
     local max = ACCESS_NONE
@@ -83,7 +81,7 @@ end
 ---@param item string
 ---@param amount? integer
 ---@param amountInLogic? integer
----@return integer
+---@return accessibilityLevel
 function HAS(item, amount, amountInLogic)
     local count = Tracker:ProviderCountForCode(item)
 
@@ -108,9 +106,3 @@ function HAS(item, amount, amountInLogic)
         return ACCESS_NONE
     end
 end
-
-
--- ANY function added here and used in access rules should try to return an Accessibility Level if it is used inside
--- the ANY() and ALL() functions
---
---

--- a/pythonProject/lua/logic_main.lua
+++ b/pythonProject/lua/logic_main.lua
@@ -1,8 +1,8 @@
--- if you want to use the graph based logic you need to create lua representations of your region/connectors/location wit the `.new()` function
+-- if you want to use the graph based logic you need to create lua representations of your region/connectors/location with the `.new()` function
 -- connect multiple of these representations with the provided one_way/two_ways() methods.
 -- this will build a graph that gets traveres via the :discover() method.
 
---To-Do: add a tutorial for the grpah absed logic into the README
+--To-Do: add a tutorial for the grpah based logic into the README
 
 -- ScriptHost:AddWatchForCode("ow_dungeon details handler", "ow_dungeon_details", owDungeonDetails)
 
@@ -33,17 +33,17 @@ local indirectConnections = {}
 
 
 ---simple helper to insert into tables and create them if not already present
----@param er_table table table to insert into
+---@param tbl table table to insert into
 ---@param key string|integer|boolean key to use to insert into the table
 ---@param value any value to insert into the table
-function Table_insert_at(er_table, key, value)
-    if er_table[key] == nil then
-        er_table[key] = {}
+function TableInsertAt(tbl, key, value)
+    if tbl[key] == nil then
+        tbl[key] = {}
     end
-    table.insert(er_table[key], value)
+    table.insert(tbl[key], value)
 end
 
---- checks if a given location is reacable in any way from any of the starting points and returns an accessibilityLevel
+--- checks if a given location is reachable in any way from any of the starting points and returns an accessibilityLevel
 --- @param name string
 --- @return accessibilityLevel
 function CanReach(name)
@@ -61,7 +61,7 @@ function CanReach(name)
         indirectConnections = {}
         while not accessibilityCacheComplete do
             accessibilityCacheComplete = true
-            entry_point:discover(ACCESS_NORMAL, 0, nil)
+            Entry_Point:discover(ACCESS_NORMAL, 0, nil)
             for dst, parents in pairs(indirectConnections) do
                 if dst:accessibility() < ACCESS_NORMAL then
                     for parent, src in pairs(parents) do
@@ -71,12 +71,12 @@ function CanReach(name)
                 end
             end
         end
-        --entry_point:discover(ACCESS_NORMAL, 0) -- since there is no code to track indirect connections, we run it twice here
-        --entry_point:discover(ACCESS_NORMAL, 0)
+        --Entry_Point:discover(ACCESS_NORMAL, 0) -- since there is no code to track indirect connections, we run it twice here
+        --Entry_Point:discover(ACCESS_NORMAL, 0)
     end
-    
+
     location = NAMED_LOCATIONS[name]
-    
+
     if location == nil then
         return ACCESS_NONE
     end
@@ -97,7 +97,7 @@ end
 ---@field side string?
 ---@field baseWorldstate "light"|"dark"|""
 ---@field worldstate "light"|"dark"|""
----@field exits table<integer, {[1]:alttp_location_new_return, [2]:function}>
+---@field exits table<integer, {[1]:{game_name_lua}_new_return, [2]:fun(): accessibilityLevel}>
 ---@field keys integer
 --you can add more stuff here for sure
 
@@ -107,20 +107,17 @@ end
 -- creates a lua object for the given name. it acts as a representation of an overworld region or indoor location and tracks its connected objects via the exit-table
 --add as many things as you like, just make sure to fill and use them properly. and maybe typehint it like shown above
 ---@param name string
----@return alttp_location_new_return
+---@return {game_name_lua}_new_return
 function {game_name_lua}_location.new(name)
+	if name == nil then
+		error("{game_name_lua}_location name cannot be nil")
+	end
     local self = setmetatable({}, {game_name_lua}_location)
-    if name then
-        NAMED_LOCATIONS[name] = self
-        self.name = name
-    else
-        NAMED_LOCATIONS[name] = self
-        self.name = tostring(self)
-    end
+	self.name = name
 
 
     -------
-    -- tyes help to denote if its interior or exterior/OW location/region
+    -- this helps to denote if it's an interior or exterior/OW location/region
     if string.find(self.name, "_inside") then
         self.side = "inside"
     elseif string.find(self.name, "_outside") then
@@ -129,9 +126,9 @@ function {game_name_lua}_location.new(name)
         self.side = ""
     end
 
-    --only usefull for ER stuff
-    self.baseWorldstate = origin
-    self.worldstate = origin
+    --only useful for ER stuff
+    -- self.baseWorldstate = origin
+    -- self.worldstate = origin
     -------
 
 
@@ -141,15 +138,15 @@ function {game_name_lua}_location.new(name)
     return self
 end
 
----function to give a default value during rule evaluations of no other rule got specified.
+---function to give a default value during rule evaluations if no other rule got specified.
 ---@return integer
 local function always()
     return ACCESS_NORMAL
 end
 
 ---marks a 1-way connections between 2 "locations/regions" in the source "locations" exit-table with rules if provided
----@param exit string|alttp_location_new_return alttp_location_new_return or code/name
----@param rule? function
+---@param exit string|{game_name_lua}_new_return {game_name_lua}_new_return or code/name
+---@param rule? fun(): accessibilityLevel|boolean
 function {game_name_lua}_location:connect_one_way(exit, rule)
     if type(exit) == "string" then
         local existing = NAMED_LOCATIONS[exit]
@@ -167,8 +164,8 @@ function {game_name_lua}_location:connect_one_way(exit, rule)
 end
 
 ---marks a 2-way connection between 2 locations. acts as a shortcut for 2 connect_one_way-calls
----@param exit string|alttp_location_new_return alttp_location_new_return or code/name
----@param rule? function
+---@param exit string|{game_name_lua}_new_return {game_name_lua}_new_return or code/name
+---@param rule? fun(): accessibilityLevel|boolean
 function {game_name_lua}_location:connect_two_ways(exit, rule)
     self:connect_one_way(exit, rule)
     exit:connect_one_way(self, rule)
@@ -177,8 +174,8 @@ end
 -- creates a 1-way connection from a region/location to another one via a 1-way connector like a ledge, hole,
 -- self-closing door, 1-way teleport, ...
 ---@param name string arbitrary name for the connection. isnt used anywhere
----@param exit string|alttp_location_new_return alttp_location_new_return or code/name
----@param rule? function
+---@param exit string|{game_name_lua}_new_return {game_name_lua}_new_return or code/name
+---@param rule? fun(): accessibilityLevel|boolean
 function {game_name_lua}_location:connect_one_way_entrance(name, exit, rule)
     if rule == nil then
         rule = always
@@ -189,8 +186,8 @@ end
 -- creates a connection between 2 locations that is traversable in both ways using the same rules both ways
 -- acts as a shortcut for 2 connect_one_way_entrance-calls
 ---@param name string arbitrary name for the connection. isnt used anywhere
----@param exit string|alttp_location_new_return alttp_location_new_return or code/name
----@param rule? function
+---@param exit string|{game_name_lua}_new_return {game_name_lua}_new_return or code/name
+---@param rule? fun(): accessibilityLevel|boolean
 function {game_name_lua}_location:connect_two_ways_entrance(name, exit, rule)
     if exit == nil then -- for ER
         return
@@ -202,9 +199,9 @@ end
 -- creates a connection between 2 locations that is traversable in both ways but each connection follow different rules.
 -- acts as a shortcut for 2 connect_one_way_entrance-calls
 ---@param name string arbitrary name for the connection. isnt used anywhere
----@param exit string|alttp_location_new_return alttp_location_new_return or code/name
----@param rule1? function
----@param rule2? function
+---@param exit string|{game_name_lua}_new_return {game_name_lua}_new_return or code/name
+---@param rule1? fun(): accessibilityLevel|boolean
+---@param rule2? fun(): accessibilityLevel|boolean
 function {game_name_lua}_location:connect_two_ways_entrance_door_stuck(name, exit, rule1, rule2)
     self:connect_one_way_entrance(name, exit, rule1)
     exit:connect_one_way_entrance(name, self, rule2)
@@ -213,16 +210,16 @@ end
 -- technically redundant but well
 -- creates a connection between 2 locations that is traversable in both ways but each connection follow different rules.
 -- acts as a shortcut for 2 connect_one_way-calls
----@param exit string|alttp_location_new_return alttp_location_new_return or code/name
----@param rule1? function
----@param rule2? function
+---@param exit string|{game_name_lua}_new_return {game_name_lua}_new_return or code/name
+---@param rule1? fun(): accessibilityLevel|boolean
+---@param rule2? fun(): accessibilityLevel|boolean
 function {game_name_lua}_location:connect_two_ways_stuck(exit, rule1, rule2)
     self:connect_one_way(exit, rule1)
     exit:connect_one_way(self, rule2)
 end
 
 ---checks for the accessibility of a regino/location given its own exit requirements
----@return 0|1|2|3|4|5|6|7
+---@return accessibilityLevel
 function {game_name_lua}_location:accessibility()
     -- only executed when run from a rules within a connection
     if currentLocation ~= nil and currentParent ~= nil then
@@ -241,16 +238,16 @@ function {game_name_lua}_location:accessibility()
 end
 
 ---function to start walking the graph them this location
----@param accessibility 0|1|2|3|4|5|6|7
+---@param accessibility accessibilityLevel
 ---@param keys integer
 function {game_name_lua}_location:discover(accessibility, keys)
-    -- checks if given Accessbibility is higer then last stored one
+    -- checks if given Accessibility is higher then last stored one
     -- prevents walking in circles
-    
+
     if accessibility > self:accessibility() then
         self.keys = math.huge -- resets keys used up to this point
         accessibilityCache[self] = accessibility
-        accessibilityCacheComplete = false -- forces CanReach tu run again/further
+        accessibilityCacheComplete = false -- forces CanReach to run again/further
     end
     if keys < self.keys then
         self.keys = keys -- sets current amout of keys used
@@ -264,13 +261,13 @@ function {game_name_lua}_location:discover(accessibility, keys)
             local location_name = self.name
 
             if location == nil then
-                location = exit[1] or empty_location-- exit name
+                location = exit[1] or empty_location -- exit name
             end
-            
+
             local oldAccess = location:accessibility() -- get most recent accessibilty level for exit
             local oldKey = location.keys or 0
-            
-            if oldAccess < accessibility then -- if new accessibility from above is higher then currently stored one, so is more accessible then before
+
+            if oldAccess < accessibility then -- if new accessibility from above is higher than the currently stored one, it is more accessible then before
                 local rule = exit[2] -- get rules to check
 
                 currentParent, currentLocation = self, location -- just set for ":accessibilty()" check within rules
@@ -289,7 +286,7 @@ function {game_name_lua}_location:discover(accessibility, keys)
                     print("Warning: " .. self.name .. " -> " .. location.name .. " rule returned nil")
                     access = ACCESS_NONE
                 end
-               
+
                 if key == nil then
                     key = keys
                 end
@@ -303,12 +300,12 @@ function {game_name_lua}_location:discover(accessibility, keys)
     end
 end
 
-Entry_point = {game_name_lua}_location.new("Entry_point")
+Entry_Point = {game_name_lua}_location.new("Entry_Point")
 
----helperfunction that is used to force a grpah update on every state change within poptracker.
+---helper function that is used to force a graph update on every state change within poptracker.
 function StateChanged()
     stale = true
-    -- entry_point:discover(AccessibilityLevel.Normal, 0)
+    -- Entry_Point:discover(AccessibilityLevel.Normal, 0)
 end
 
 ScriptHost:AddWatchForCode("StateChanged", "*", StateChanged)

--- a/pythonProject/lua/luaitems.lua
+++ b/pythonProject/lua/luaitems.lua
@@ -97,15 +97,18 @@ end
 function CreateLuaManualStorageItem(name)
     local self = ScriptHost:CreateLuaItem()
     -- self.Type = "custom"
-    self.Name = name --code --
+    self.Name = name -- code
     self.Icon = ImageReference:FromPackRelativePath("/images/items/closed_Chest.png")
+	---@type table<string, any>
     self.ItemState = {
+		---@type table<string, string[]>
         MANUAL_LOCATIONS = {
             ["default"] = {}
-        }, --[[@as table<string, string[]>]]
+        },
+		---@type string[]
         MANUAL_LOCATIONS_ORDER = {}
         -- you can add many more custom stuff in here
-    } --[[@as table<string, any>]]
+    }
 
     self.CanProvideCodeFunc = CanProvideCodeFunc
     self.OnLeftClickFunc = OnLeftClickFunc -- your_custom_leftclick_function_here

--- a/pythonProject/lua/luaitems.lua
+++ b/pythonProject/lua/luaitems.lua
@@ -8,7 +8,7 @@ local function CanProvideCodeFunc(self, code)
     return code == self.Name
 end
 
----function that get triggered when left clicking a lua items as hosted item or in an itemgrid
+---function that gets triggered when left clicking a lua items as hosted item or in an itemgrid
 ---will do whatever you want it to
 ---@param self LuaItem
 local function OnLeftClickFunc(self)
@@ -16,7 +16,7 @@ local function OnLeftClickFunc(self)
     -- return true
 end
 
----function that get triggered when right clicking a lua items as hosted item or in an itemgrid
+---function that gets triggered when right clicking a lua items as hosted item or in an itemgrid
 ---will do what ever you want it to
 ---@param self LuaItem
 local function OnRightClickFunc(self)
@@ -24,7 +24,7 @@ local function OnRightClickFunc(self)
     -- return true
 end
 
----function that get triggered when middle clicking a lua items as hosted item or in an itemgrid
+---function that gets triggered when middle clicking a lua items as hosted item or in an itemgrid
 ---will dp whatever you want it to
 ---@param self LuaItem
 local function OnMiddleClickFunc(self)
@@ -41,13 +41,12 @@ end
 ---@return integer
 local function ProvidesCodeFunc(self, code)
     if CanProvideCodeFunc(self, code) then
-
-            return 1
-        end
+		return 1
+	end
     return 0
 end
 
----save function triggered on closing popotracker to have a state to restore later on. specific to custom preudo-cache LuaItems
+---save function triggered on closing poptracker to have a state to restore later on. specific to custom pseudo-cache LuaItems
 ---@param self LuaItem
 ---@return table
 local function SaveManualLocationStorageFunc(self)
@@ -61,7 +60,7 @@ local function SaveManualLocationStorageFunc(self)
     }
 end
 
----function triggered on loading the pack to restore the lat saves state. specific to custom preudo-cache LuaItems
+---function triggered on loading the pack to restore the last saved state. specific to custom pseudo-cache LuaItems
 ---@param self LuaItem
 ---@param data table
 local function LoadManualLocationStorageFunc(self, data)
@@ -90,7 +89,7 @@ end
 
 ------
 
----creates an empty pseudo cache item to store various states for up to 10 seeds to restroe when reconncing to those.
+---creates an empty pseudo cache item to store various states for up to 10 seeds to restroe when reconncting to those.
 ---mainly intended for manually marked off locations like shops or inspected locations OR for item states that have been
 ---manually set because they are hard to infer from game/server state
 ---@param name string

--- a/pythonProject/lua/luaitems.lua
+++ b/pythonProject/lua/luaitems.lua
@@ -101,7 +101,7 @@ function CreateLuaManualStorageItem(name)
     self.Icon = ImageReference:FromPackRelativePath("/images/items/closed_Chest.png")
 	---@type table<string, any>
     self.ItemState = {
-		---@type table<string, string[]>
+		---@type table<string, table<string, integer>>
         MANUAL_LOCATIONS = {
             ["default"] = {}
         },

--- a/pythonProject/lua/watches.lua
+++ b/pythonProject/lua/watches.lua
@@ -1,7 +1,7 @@
- Archipelago:AddClearHandler("clear handler", onClear)
---Archipelago:AddClearHandler("clear handler", OnClearHandler)
+Archipelago:AddClearHandler("clear handler", OnClear)
 Archipelago:AddItemHandler("item handler", OnItem)
 Archipelago:AddLocationHandler("location handler", OnLocation)
 
 Archipelago:AddSetReplyHandler("notify handler", OnNotify)
 Archipelago:AddRetrievedHandler("notify launch handler", OnNotifyLaunch)
+-- ScriptHost:AddWatchForCode("settings autofill handler", "autofill_settings", AutoFill)


### PR DESCRIPTION
- Fix as many typos as I could find in the Lua files
- Update some comments to be clearer
- Update annotations to be more precise, and fix a couple incorrect annotations
- Update some function names to match standard
- Replace references to ALttP with replacer template
- Update `require` calls to use `.` instead of `/` to match Lua spec