### PR TITLE
Add duplicate name check for NAMED_LOCATIONS in .new()

### DIFF
--- a/pythonProject/lua/logic_main.lua
+++ b/pythonProject/lua/logic_main.lua
@@ -112,6 +112,9 @@ function {game_name_lua}_location.new(name)
 	if name == nil then
 		error("{game_name_lua}_location name cannot be nil")
 	end
+	if NAMED_LOCATION[name] then
+		print("{game_name_lua}_location " .. name .. " already exists")
+	end
     local self = setmetatable({}, {game_name_lua}_location)
 	self.name = name
     NAMED_LOCATIONS[name] = self


### PR DESCRIPTION
Print to console if a region of the given name already exists in NAMED_LOCATIONS when creating a new region. Currently just prints and continues as normal, overwriting the old entry, but could easily be swapped with an error instead if wanted